### PR TITLE
Use ref instead of querySelectorAll

### DIFF
--- a/index.js
+++ b/index.js
@@ -242,12 +242,18 @@ const cardStyles = {
 }
 
 class Card extends React.Component {
-  componentDidMount() {
-    VanillaTilt.init(document.querySelectorAll('[data-tilt]'))
+  constructor(props) {
+    super(props)
+    this.tiltRef = React.createRef();
   }
+  
+  componentDidMount() {
+    VanillaTilt.init(this.tiltRef.current)
+  }
+  
   render() {
     const styles = Object.assign({}, cardStyles, this.props.style)
-    return <div data-tilt style={styles} {...this.props} />
+    return <div ref={this.tiltRef} style={styles} {...this.props} />
   }
 }
 


### PR DESCRIPTION
Hi, Siddharth 👋 Here's the pull we [discussed on Twitter](https://twitter.com/siddharthkp/status/1001918028089647104).

Problem
---

`querySelectorAll` was used in the `componentDidMount` hook of `Card` to select the DOM elements to be initialized. When there are multiple instances of the `Card` on a page, `querySelectorAll('[data-tilt]')` will select all of them, so every card will get initialized multiple times (once in each componentDidMount).

Solution
---

Use a [ref](https://reactjs.org/docs/refs-and-the-dom.html) to select the DOM node so each card only gets initialized once. 

I tested this solution in CodeSandbox and everything seemed to work fine but it's probably best if you double-check it to be safe.